### PR TITLE
Allow custom null costs

### DIFF
--- a/src/main/java/com/conveyal/r5/rastercost/CustomCostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/CustomCostField.java
@@ -59,23 +59,74 @@ public class CustomCostField implements CostField, Serializable {
     */
     private final String displayKey;
 
+<<<<<<< Updated upstream
+=======
+    // define the sensitivity coefficient for the custom cost field
+    // currently also supports negative number
+    // this is needed for deriving multiple routes with different weights to custom cost
+    private double sensitivityCoefficient;
+
+    // CustomCostFactors are used to calculate the custom cost addition "cost seconds" 
+    // consists of osmId as the key and custom cost factor as value
+    private HashMap<Long, Double> customCostFactors = null;
+
+    // Flag for allowing null's for custom cost edges.
+    // If this is false the routing will force custom cost values for each edge so
+    // the rouiting will crash if no value found for each edge traversed
+    // if set to true, the processed edge will get a custom cost value of 0
+    private boolean allowNullCustomCostEdges;
+
+    /** 
+    * base edge travel times by osmid
+    * these costs are without the custom cost addition
+    *
+    * Key is osmId, value is base traversal time in seconds
+    */
+    private HashMap<Long, Integer> baseTraveltimes = new HashMap<Long, Integer>();
+
+    /**
+     * custom cost travel times by osmid
+     * these costs are the custom cost addition costs which are added to the base traversal time
+     * they are treated as seconds but are actually costs or "cost seconds"
+     * these values are calculaeted using formula: basetraveltime * customcostfactor * sensitivitycoefficient
+     * and then added to the base traversal time for each edge
+     * 
+     * Key is osmId, value is addition custom cost time as costs (seconds)
+     */
+    private HashMap<Long, Integer> customCostAdditionalTraveltimes = new HashMap<Long, Integer>();
+
+>>>>>>> Stashed changes
 
 /**
  * 
  * @param displayKey
- * displayKey currently not really used, implemented due to CostField interface
+ * usefull when using multiple custom cost instances for naming
+ * also implemented due to CostField interface
  * @param sensitivityCoefficient
  * sensitivityCoefficient can currently also be a negative number
  * the only restricting factor is that the routing logic in MultistageTraversalTimeCalculator
  * will fallback to a positive number 1 if the sum of basetraversaltime + all custom cost found for that edge
  * will be less than 1. This is because the routing logic will not allow negative traversal times.
+<<<<<<< Updated upstream
  * @param customCostMap
  * customCostMap has osmId as the key and the custom cost seconds as the value
  */
     public CustomCostField (String displayKey, double sensitivityCoefficient, HashMap<Long, Double> customCostMap) {
         validateCustomCostMap(customCostMap);
+=======
+ * @param customCostFactors
+ * customCostFactors has osmId as the key and the custom cost seconds as the value
+ * @param allowNullCustomCostEdges
+ * flag for allowing or disallowing null costs for osmids in the customCostFactors
+ * if this is false, every edge/osmid key needs to have a value in the HashMap, otheriwse will throw error
+ * if true, will just fallback to 0 additionalSeconds for each edge where customCost value not found
+ */
+    public CustomCostField (String displayKey, double sensitivityCoefficient, HashMap<Long, Double> customCostFactors, boolean allowNullCustomCostEdges) {
+        validateCustomCostFactors(customCostFactors);
+>>>>>>> Stashed changes
         this.sensitivityCoefficient = sensitivityCoefficient;
         this.displayKey = displayKey;
+        this.allowNullCustomCostEdges = allowNullCustomCostEdges;
     }
 
     /**
@@ -100,27 +151,50 @@ public class CustomCostField implements CostField, Serializable {
         long edgeOsmId = currentEdge.getOSMID();
         // get the custom cost factor from the custom cost map using the edgeas osmId as key
         Long keyOsmId = Long.valueOf(edgeOsmId);
+<<<<<<< Updated upstream
         Object customCostValue = this.customCostMap.get(keyOsmId);
         // throw an error if no custom cost is found
+=======
+        // save the base traversal seconds
+        baseTraveltimes.put(keyOsmId, baseTraversalTimeSeconds);
+        // get custom cost factor using the osmId as key
+        Object customCostValue = this.customCostFactors.get(keyOsmId);
+        // if custom cost not found and flag for allowing null/not found costs is set
+        if (customCostValue == null && this.allowNullCustomCostEdges) {
+            // setting to 0 for no effect, also will prevent from going to exception due to not null
+            customCostValue = 0.0;
+        }
+        // if customCostValue from HashMap was null and flag allowNullcustomCostEdges is false
+>>>>>>> Stashed changes
         if (customCostValue == null) {
             throw new CustomCostFieldException("Custom cost not found for edge with osmId: " + currentEdge.getOSMID());
         }
-        // check the type (Integer or Double) and cast to Double if needed
-        Double customCostFactor;
-        if (customCostValue instanceof Integer) {
-            customCostFactor = ((Integer) customCostValue).doubleValue();
-        } else if (customCostValue instanceof Double) {
-            customCostFactor = (Double) customCostValue;
-        } else {
-            throw new CustomCostFieldException("Unexpected type (should be number) for custom cost with osmId: " + currentEdge.getOSMID());
-        }   
-        // calculate seconds to be added to the base traversal time 
-        // multiply the base travel time with custom cost factor and sensitivity coefficient
-        // this value is then added to the base traversal time
-        Double additionalCostSeconds = baseTraversalTimeSeconds * customCostFactor * this.sensitivityCoefficient;
-        // throw an error if the custom cost is NaN
-        if (Double.isNaN(additionalCostSeconds)) {
-            throw new CustomCostFieldException("Custom cost addition result is NaN for osmId:  " + currentEdge.getOSMID());
+
+        Double additionalCostSeconds;
+        // if customCostValue is 0.0, or was set to 0.0 because was null and flag allowNullCustomCostEdges is true
+        // skip calculating the additional custom cost time and fallback to 0.0
+        if (customCostValue.equals(0.0)) {
+            additionalCostSeconds = 0.0;
+        }
+        // calculate the additionalCostSeconds for edge where customCostValue is found
+        else {
+            // cast to Double if needed
+            Double customCostFactor;
+            if (customCostValue instanceof Integer) {
+                customCostFactor = ((Integer) customCostValue).doubleValue();
+            } else if (customCostValue instanceof Double) {
+                customCostFactor = (Double) customCostValue;
+            } else {
+                throw new CustomCostFieldException("Unexpected type (should be number) for custom cost with osmId: " + currentEdge.getOSMID());
+            }   
+            // calculate seconds to be added to the base traversal time 
+            // multiply the base travel time with custom cost factor and sensitivity coefficient
+            // this value is then added to the base traversal time
+            additionalCostSeconds = baseTraversalTimeSeconds * customCostFactor * this.sensitivityCoefficient;
+            // throw an error if the custom cost is NaN
+            if (Double.isNaN(additionalCostSeconds)) {
+                throw new CustomCostFieldException("Custom cost addition result is NaN for osmId:  " + currentEdge.getOSMID());
+            }
         }
         // value is rounded and casted to int for seconds
         return (int) Math.round(additionalCostSeconds);

--- a/src/main/java/com/conveyal/r5/rastercost/CustomCostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/CustomCostField.java
@@ -42,14 +42,6 @@ import java.util.List;
 /* GP2 edit: create this class to be used in Greenpaths custom cost exposure routing */
 public class CustomCostField implements CostField, Serializable {
 
-    // custom cost map has osmId as the key and additional seconds as value
-    public HashMap<Long, Double> customCostMap = null;
-
-    // define the sensitivity coefficient for the custom cost field
-    // currently also supports negative number
-    // this is needed for deriving multiple routes with different weights to custom cost
-    public double sensitivityCoefficient = 1;
-
     /** 
     * displayKey currently not really used, implemented due to CostField interface
     *
@@ -59,8 +51,6 @@ public class CustomCostField implements CostField, Serializable {
     */
     private final String displayKey;
 
-<<<<<<< Updated upstream
-=======
     // define the sensitivity coefficient for the custom cost field
     // currently also supports negative number
     // this is needed for deriving multiple routes with different weights to custom cost
@@ -95,7 +85,6 @@ public class CustomCostField implements CostField, Serializable {
      */
     private HashMap<Long, Integer> customCostAdditionalTraveltimes = new HashMap<Long, Integer>();
 
->>>>>>> Stashed changes
 
 /**
  * 
@@ -107,13 +96,6 @@ public class CustomCostField implements CostField, Serializable {
  * the only restricting factor is that the routing logic in MultistageTraversalTimeCalculator
  * will fallback to a positive number 1 if the sum of basetraversaltime + all custom cost found for that edge
  * will be less than 1. This is because the routing logic will not allow negative traversal times.
-<<<<<<< Updated upstream
- * @param customCostMap
- * customCostMap has osmId as the key and the custom cost seconds as the value
- */
-    public CustomCostField (String displayKey, double sensitivityCoefficient, HashMap<Long, Double> customCostMap) {
-        validateCustomCostMap(customCostMap);
-=======
  * @param customCostFactors
  * customCostFactors has osmId as the key and the custom cost seconds as the value
  * @param allowNullCustomCostEdges
@@ -123,7 +105,6 @@ public class CustomCostField implements CostField, Serializable {
  */
     public CustomCostField (String displayKey, double sensitivityCoefficient, HashMap<Long, Double> customCostFactors, boolean allowNullCustomCostEdges) {
         validateCustomCostFactors(customCostFactors);
->>>>>>> Stashed changes
         this.sensitivityCoefficient = sensitivityCoefficient;
         this.displayKey = displayKey;
         this.allowNullCustomCostEdges = allowNullCustomCostEdges;
@@ -132,11 +113,11 @@ public class CustomCostField implements CostField, Serializable {
     /**
      * Check that the custom cost map is not empty, do we need more validation?
      */
-    private void validateCustomCostMap(HashMap<Long, Double> customCostMap) {
-        if (customCostMap == null || customCostMap.isEmpty()) {
-            throw new IllegalArgumentException("Custom cost map cant be empty when initializing CustomCostField");
+    private void validateCustomCostFactors(HashMap<Long, Double> customCostFactors) {
+        if (customCostFactors == null || customCostFactors.isEmpty()) {
+            throw new IllegalArgumentException("Custom cost map can't be empty when initializing CustomCostField");
         }
-        this.customCostMap = customCostMap;
+        this.customCostFactors = customCostFactors;
     }
 
     /**
@@ -151,10 +132,6 @@ public class CustomCostField implements CostField, Serializable {
         long edgeOsmId = currentEdge.getOSMID();
         // get the custom cost factor from the custom cost map using the edgeas osmId as key
         Long keyOsmId = Long.valueOf(edgeOsmId);
-<<<<<<< Updated upstream
-        Object customCostValue = this.customCostMap.get(keyOsmId);
-        // throw an error if no custom cost is found
-=======
         // save the base traversal seconds
         baseTraveltimes.put(keyOsmId, baseTraversalTimeSeconds);
         // get custom cost factor using the osmId as key
@@ -165,7 +142,6 @@ public class CustomCostField implements CostField, Serializable {
             customCostValue = 0.0;
         }
         // if customCostValue from HashMap was null and flag allowNullcustomCostEdges is false
->>>>>>> Stashed changes
         if (customCostValue == null) {
             throw new CustomCostFieldException("Custom cost not found for edge with osmId: " + currentEdge.getOSMID());
         }
@@ -196,8 +172,11 @@ public class CustomCostField implements CostField, Serializable {
                 throw new CustomCostFieldException("Custom cost addition result is NaN for osmId:  " + currentEdge.getOSMID());
             }
         }
+        int roundedAdditionalCostSeconds = (int) Math.round(additionalCostSeconds);
+        // save the custom cost addition costs
+        customCostAdditionalTraveltimes.put(keyOsmId, roundedAdditionalCostSeconds);
         // value is rounded and casted to int for seconds
-        return (int) Math.round(additionalCostSeconds);
+        return roundedAdditionalCostSeconds;
     }
 
     // currently not really used, implemented due to CostField interface
@@ -211,8 +190,24 @@ public class CustomCostField implements CostField, Serializable {
     public double getDisplayValue (int osmIdKey) {
         // will need this conversation because implementation needs int but key is long
         Long osmIdKeyLong = Long.valueOf(osmIdKey);
-        return this.customCostMap.get(osmIdKeyLong);
+        return this.customCostFactors.get(osmIdKeyLong);
     }
+
+    public double getSensitivityCoefficient() {
+        return sensitivityCoefficient;
+    }
+
+    public HashMap<Long, Double> getCustomCostFactors() {
+        return customCostFactors;
+    }
+
+    public HashMap<Long, Integer> getBaseTraveltimes() {
+        return baseTraveltimes;
+    }
+
+    public HashMap<Long, Integer> getcustomCostAdditionalTraveltimes() {
+        return customCostAdditionalTraveltimes;
+    }   
 
     // convert 1-n custom cost fields to a list of custom cost fields
     public static List<CostField> wrapToEdgeStoreCostFieldsList(CostField... customCostFields) {

--- a/src/test/java/com/conveyal/r5/customcost/CustomCostTest.java
+++ b/src/test/java/com/conveyal/r5/customcost/CustomCostTest.java
@@ -6,9 +6,13 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,13 +37,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CustomCostTest {
     private static final Logger LOG = LoggerFactory.getLogger(ReverseRoutingTest.class);
 
-    HashMap<Long, Double> customCostHashMap;
+    HashMap<Long, Double> staticCustomCostHashMap;
 
     @BeforeEach
     public void setUp () throws Exception {
-        customCostHashMap = generateCustomCostHashMap();
+        staticCustomCostHashMap = generateCustomCostHashMap();
     }
 
+    // this is used in places where no customised cost map is needed
     public static HashMap<Long, Double> generateCustomCostHashMap() {
         HashMap<Long, Double> osmIdMap = new HashMap<>();
         // put a known value as the first in the hashmap
@@ -57,26 +62,27 @@ public class CustomCostTest {
 
     @Test
     public void testCreateValidCustomCostField () {
-        CustomCostField customCostInstance = new CustomCostField("testKey", 3, customCostHashMap);
-        double targetValue = customCostHashMap.get(123123L);
+        CustomCostField customCostInstance = new CustomCostField("testKey", 3, staticCustomCostHashMap, false);
+        double targetValue = staticCustomCostHashMap.get(123123L);
         assertEquals(customCostInstance.getDisplayKey(), "testKey");
         assertEquals(targetValue, 7.0);
-        assertEquals(customCostHashMap.size() > 0, true);
+        assertEquals(staticCustomCostHashMap.size() > 0, true);
     }
 
     @Test
     public void testCreateInvalidCustomCostField () {
         HashMap<Long, Double> emptyHashmap = new HashMap<>();
         // assertThrows(IllegalArgumentException.class, );
-        assertThrows(IllegalArgumentException.class, () -> new CustomCostField("testKey", 3, emptyHashmap));
-        assertThrows(IllegalArgumentException.class, () -> new CustomCostField("testKey", 3, null));
+        assertThrows(IllegalArgumentException.class, () -> new CustomCostField("testKey", 3, emptyHashmap, false));
+        assertThrows(IllegalArgumentException.class, () -> new CustomCostField("testKey", 3, null, false));
     }
 
     /**
      * Got the grid layout and the test from SimpsonDesertTests.java
      */
-    @Test
-    public void testRoutingWithCustomCosts() { 
+    @ParameterizedTest
+    @MethodSource("customCostTestParameterProvider")
+    public void testRoutingWithCustomCosts(boolean allowNullCustomCostEdges) { 
         // this test could be made more robust by:
         // 1. use different methods of creating the network and the task
         // which would let us see that the times have increased the amount we set
@@ -87,19 +93,11 @@ public class CustomCostTest {
 
         GridLayout gridLayout = new GridLayout(SIMPSON_DESERT_CORNER, 6);
         TransportNetwork Network = gridLayout.generateNetwork();
-        // take all the osmIds that the network has
+  
+        // take osmIds that the network has
+        // if allowNullCustomCostEdges is true, take only 1/2 of osids for testing missing osmids
         // add them to a list and make sure that they exist
-        // notice: for some reason this logic doesn't find all the osmIds
-        List<Long> osmIds = new ArrayList<>();
-        EdgeStore.Edge e = Network.streetLayer.edgeStore.getCursor(0);
-        do {
-            osmIds.add(e.getOSMID());
-        } while (e.advance());
-
-        final List<Long> uniqueOsmIds = osmIds.stream().distinct().collect(Collectors.toList());
-
-        assertTrue(uniqueOsmIds.size() > 0);
-
+        List<Long> uniqueOsmIds = getOsmIds(Network, allowNullCustomCostEdges);
         HashMap<Long, Double> customCostHashMap = new HashMap<>();
         // add the acquired osmIds to a hashmap with random values
         for (Long osmId : uniqueOsmIds) {
@@ -109,7 +107,7 @@ public class CustomCostTest {
         }
 
         // add the hashmap as the customCostHashMap to the customCostInstance
-        CustomCostField customCostInstance = new CustomCostField("testKey", 2, customCostHashMap);
+        CustomCostField customCostInstance = new CustomCostField("testKey", 2, customCostHashMap, allowNullCustomCostEdges);
         Network.streetLayer.edgeStore.costFields = CustomCostField.wrapToEdgeStoreCostFieldsList(customCostInstance);
 
         // build the task from the grid, example taken from SimpsonDesertTests.java
@@ -127,11 +125,20 @@ public class CustomCostTest {
         assertTrue(oneOriginResult.osmIdResults.size() > 0);
         assertTrue(oneOriginResult.travelTimes.nPoints > 0);
 
-        // test that the routing result osmId has only valid osmIds which are found from the network
-        // this is important, that atleast some values have the same osmids -> they will be added custom costs
-        boolean hasOnlyValidOsmIdsFoundFromNetwork = oneOriginResult.osmIdResults.stream()
-            .allMatch(innerList -> innerList.stream().allMatch(uniqueOsmIds::contains));
-        assertTrue(hasOnlyValidOsmIdsFoundFromNetwork);
+        // test that the routing result osmId has valid osmIds which are found from the network
+        // test for some valid if using partial osmids, test for allMatch if using all osmids
+        if(allowNullCustomCostEdges) {
+            // Check if any OSM ID from the results is in the subset
+            boolean hasSomeValidOsmIdsFoundFromNetwork = oneOriginResult.osmIdResults.stream()
+                .flatMap(List::stream)
+                .anyMatch(uniqueOsmIds::contains);
+            assert(hasSomeValidOsmIdsFoundFromNetwork);
+        }
+        else {
+            boolean hasOnlyValidOsmIdsFoundFromNetwork = oneOriginResult.osmIdResults.stream()
+                .allMatch(innerList -> innerList.stream().allMatch(uniqueOsmIds::contains));
+            assertTrue(hasOnlyValidOsmIdsFoundFromNetwork);
+        }
 
         int [][] travelTimeValues = oneOriginResult.travelTimes.getValues();
 
@@ -171,13 +178,94 @@ public class CustomCostTest {
 
         // check that customCost value is always same or bigger, never smaller
         assertTrue(allValuesIncreasedOrSame);
+<<<<<<< Updated upstream
     }
 
      @Test
     public void testInvalidCustomCostMapOsmIdNotFound() { 
+=======
+
+        // test that the custom cost values are correctly applied
+        // and that the base time and custom cost "time" maps have correct values
+
+        assertTrue(customCostFieldsList.size() > 0);
+
+        // check that all the customCostFields have non-empty baseTraveltimesMap
+        // and uniqueOsmIds size is the same and all the osmIds are found from the map
+        // for they are were traversed so they should be present
+        for (CustomCostField customCostField : customCostFieldsList) {
+            HashMap<Long, Integer> baseTraveltimesMap = customCostField.getBaseTraveltimes();
+            assertTrue(baseTraveltimesMap.size() > 0);
+            if(!allowNullCustomCostEdges) {
+                assertTrue(baseTraveltimesMap.size() == uniqueOsmIds.size());
+                assertTrue(baseTraveltimesMap.keySet().stream().allMatch(uniqueOsmIds::contains));
+            }
+            else {
+                assertTrue(baseTraveltimesMap.size() > uniqueOsmIds.size());
+                assertTrue(baseTraveltimesMap.keySet().stream().anyMatch(uniqueOsmIds::contains));
+            }
+        }
+
+        // check that the maps have correct values and that we get same values from the map and the manual calculation
+        for (CustomCostField customCostField : customCostFieldsList) {
+            HashMap<Long, Integer> baseTraveltimesMap = customCostField.getBaseTraveltimes();
+            HashMap<Long, Integer> customCostAdditionalTravelTimesMap = customCostField.getcustomCostAdditionalTraveltimes();
+            for (Long osmId : uniqueOsmIds) {
+                // calculate cost manually
+                int baseTraveltime = baseTraveltimesMap.get(osmId);
+                double customCostFactor = customCostHashMap.get(osmId);
+                double sensitivity = customCostField.getSensitivityCoefficient();
+                // custom cost additional seconds added to base travel time
+                int additionalCostSeconds = (int) Math.round(baseTraveltime * customCostFactor * sensitivity);
+                // final travel time with custom cost
+                int finalManuallyCalculatedCost = baseTraveltime + additionalCostSeconds;
+                // use maps to get the final travel time with custom cost using osmId as key
+                int customCostAdditionalTraveltimeCost = customCostAdditionalTravelTimesMap.get(osmId);
+                // final travel time with custom cost from maps
+                int customCostFinalTraveltimeCostFromMaps = baseTraveltime + customCostAdditionalTraveltimeCost;
+                // see that manually calculated value match with maps values
+                assertEquals(finalManuallyCalculatedCost, customCostFinalTraveltimeCostFromMaps);
+            }
+        }
+    }
+
+    // use parameterization for testing allowNullCustomCostEdges flag
+    // for all osmids and just some osmids
+    static Stream<Arguments> customCostTestParameterProvider() {
+        return Stream.of(
+            // run with for all osmIds
+            Arguments.of(false),
+            // run with some osmIds
+            Arguments.of(true)
+        );
+    }
+
+    public List<Long> getOsmIds(TransportNetwork network, boolean getOnlyPartialOsmidList) {
+        List<Long> osmIds = new ArrayList<>();
+        EdgeStore.Edge e = network.streetLayer.edgeStore.getCursor(0);
+        do {
+            osmIds.add(e.getOSMID());
+        } while (e.advance());
+
+        List<Long> uniqueOsmIds = osmIds.stream().distinct().collect(Collectors.toList());
+
+        assertTrue(uniqueOsmIds.size() > 0);
+
+        // get only 1/3 of all osmids
+        // used to test flag allowNullCustomCostEdges
+        if (getOnlyPartialOsmidList) {
+            uniqueOsmIds = uniqueOsmIds.subList(0, uniqueOsmIds.size() / 2);
+        }
+      
+        return uniqueOsmIds;
+    }
+
+    @Test
+    public void testInvalidCustomCostFactorsOsmIdNotFound() { 
+>>>>>>> Stashed changes
         GridLayout gridLayout = new GridLayout(SIMPSON_DESERT_CORNER, 6);
         TransportNetwork Network = gridLayout.generateNetwork();
-        CustomCostField customCostInstance = new CustomCostField("testKey", 1.5, customCostHashMap);
+        CustomCostField customCostInstance = new CustomCostField("testKey", 1.5, staticCustomCostHashMap, false);
         Network.streetLayer.edgeStore.costFields = CustomCostField.wrapToEdgeStoreCostFieldsList(customCostInstance);
 
         // build the task from the grid, example taken from SimpsonDesertTests.java

--- a/src/test/java/com/conveyal/r5/customcost/CustomCostTest.java
+++ b/src/test/java/com/conveyal/r5/customcost/CustomCostTest.java
@@ -110,6 +110,7 @@ public class CustomCostTest {
         CustomCostField customCostInstance = new CustomCostField("testKey", 2, customCostHashMap, allowNullCustomCostEdges);
         Network.streetLayer.edgeStore.costFields = CustomCostField.wrapToEdgeStoreCostFieldsList(customCostInstance);
 
+
         // build the task from the grid, example taken from SimpsonDesertTests.java
         AnalysisWorkerTask task = gridLayout.newTaskBuilder()
                 .setOrigin(2, 2)
@@ -118,8 +119,20 @@ public class CustomCostTest {
                 .monteCarloDraws(1)
                 .build();
 
+        List<CustomCostField> customCostFieldsList = Network.streetLayer.edgeStore.costFields.stream()
+            .map(CustomCostField.class::cast)
+            .collect(Collectors.toList());
+
+        assertTrue(customCostFieldsList.size() > 0);
+
+        // assert that all the customCostFields have empty baseTraveltimesMap
+        for (CustomCostField customCostField : customCostFieldsList) {
+            assertTrue(customCostField.getBaseTraveltimes().size() == 0);
+        }
+
         TravelTimeComputer computer = new TravelTimeComputer(task, Network);
         OneOriginResult oneOriginResult = computer.computeTravelTimes();
+
 
         assert(oneOriginResult != null);
         assertTrue(oneOriginResult.osmIdResults.size() > 0);
@@ -150,9 +163,10 @@ public class CustomCostTest {
 
 
         // REMOVE COSTFIELDS FROM NETWORK AND RUN ROUTING FOR COMPARISON
-
-        Network.streetLayer.edgeStore.costFields = null;
-        TravelTimeComputer computerNoCustomCosts = new TravelTimeComputer(task, Network);
+        // copy network to new variable
+        TransportNetwork NetworkNoCustomCosts = Network;
+        NetworkNoCustomCosts.streetLayer.edgeStore.costFields = null;
+        TravelTimeComputer computerNoCustomCosts = new TravelTimeComputer(task, NetworkNoCustomCosts);
         OneOriginResult oneOriginResultNoCustomCosts = computerNoCustomCosts.computeTravelTimes();
 
         assertTrue(oneOriginResultNoCustomCosts != null);
@@ -178,12 +192,6 @@ public class CustomCostTest {
 
         // check that customCost value is always same or bigger, never smaller
         assertTrue(allValuesIncreasedOrSame);
-<<<<<<< Updated upstream
-    }
-
-     @Test
-    public void testInvalidCustomCostMapOsmIdNotFound() { 
-=======
 
         // test that the custom cost values are correctly applied
         // and that the base time and custom cost "time" maps have correct values
@@ -262,7 +270,6 @@ public class CustomCostTest {
 
     @Test
     public void testInvalidCustomCostFactorsOsmIdNotFound() { 
->>>>>>> Stashed changes
         GridLayout gridLayout = new GridLayout(SIMPSON_DESERT_CORNER, 6);
         TransportNetwork Network = gridLayout.generateNetwork();
         CustomCostField customCostInstance = new CustomCostField("testKey", 1.5, staticCustomCostHashMap, false);
@@ -278,8 +285,7 @@ public class CustomCostTest {
 
         TravelTimeComputer computer = new TravelTimeComputer(task, Network);
 
-        // make sure that invalid customCostMap throws CustomCostFieldException
-        // error happens in additionalTraversalTimeSeconds -> Double customCostFactor = this.customCostMap.get(keyOsmId);
+        // make sure that invalid customCostFactors throws CustomCostFieldException
         Exception exception = assertThrows(CustomCostFieldException.class, () -> {
             computer.computeTravelTimes();
         });


### PR DESCRIPTION
r5_gp2 edit.

added flag which enables support for null costs in the customCostFactors HashMap, added to tests

basically this enables to run the r5 routing with customCostFactor HashMap/Dict which doesn't have all the values. If the flag allowNullCustomCostEdges is False -> will crash if any osmid used in the routing is not found.